### PR TITLE
Remove unused files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
 	"version": "1.3.0",
 	"description": "extended POSIX-style sprintf",
 	"main": "./lib/extsprintf.js",
+	"files": [
+		"./lib/extsprintf.js"
+	],
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/davepacheco/node-extsprintf.git"


### PR DESCRIPTION
All files (besides `./lib/extsprintf.js`) should not be in package - this will reduce it's size for `npm install`.